### PR TITLE
St fix to support ruby19

### DIFF
--- a/lib/prolly/ps/storage/mongodb.rb
+++ b/lib/prolly/ps/storage/mongodb.rb
@@ -53,7 +53,7 @@ module Prolly
         def uniq_vals(name)
           @session[:samples].aggregate([
             { "$match" => { name.to_sym => { "$exists" => true } } },
-            { "$group" => { "_id": "$#{name}" } }
+            { "$group" => { "_id" => "$#{name}" } }
           ]).map { |e| e["_id"] }
         end
 

--- a/lib/prolly/ps/storage/rubylist.rb
+++ b/lib/prolly/ps/storage/rubylist.rb
@@ -7,7 +7,7 @@ module Prolly
       class Rubylist < Base
 
         def initialize
-          super
+          reset
         end
 
         def reset


### PR DESCRIPTION
Fix to support ruby 1.9
   - replace colon with arrows as colon with String Object as hash keys
    not supported in 1.9

Update initialize block 
- virtual attributes are not initialized properly
- #reset method has necessary code to initialize the virtual attributes.
- just update initialize block by calling #reset
